### PR TITLE
Nested transforms of generic key objects possible

### DIFF
--- a/packages/administration/Filter/Mapping.ts
+++ b/packages/administration/Filter/Mapping.ts
@@ -56,6 +56,9 @@ export namespace Mapping {
 				? map && Array.isArray(value) // TODO: make it work for nested arrays
 					? value.map(item => Transform.to[type](item))
 					: Transform.to[type](value)
+				: Array.isArray(type)
+				? // TODO: fix cast to 'any'
+				  Transform.to[type[0]](value).map((item: any) => this.filter(item, type[1]))
 				: Array.isArray(value)
 				? value.map(item => this.filter(item, type))
 				: this.filter(value, type)

--- a/packages/administration/Filter/mapping.spec.ts
+++ b/packages/administration/Filter/mapping.spec.ts
@@ -11,7 +11,7 @@ describe("Mapping and filtering", () => {
 })
 const event = {
 	stringVal: "test",
-	numVal: 2,
+	numVal: 2.34,
 	tuple: ["key", { inner: "value" }],
 	array: [{ inner: "value0" }, { inner: "value1" }, { inner: "value2" }, { inner: "value3" }],
 	nested: {
@@ -23,10 +23,12 @@ const event = {
 		// ],
 	},
 	map: { prop1: "hej", prop2: "haj" },
+	map2: { pi: 3.1416, phi: 1.618 },
 }
 const mapping = {
 		stringVal: "stringVal",
-		numVal: { selector: "numVal", transform: "integer" },
+		integer: { selector: "numVal", transform: "integer" },
+		numeric: { selector: "numVal", transform: "number" },
 		tupleKey: "tuple[0]",
 		tupleInner: "tuple[1].inner",
 		arrayInner: "array[*].inner",
@@ -42,6 +44,7 @@ const mapping = {
 		},
 		// TODO nestedDoubleArray: "nested.doubleArray[*][*].inner",
 		map: { selector: "map", transform: "array" },
+		num2strMap: { selector: "map2", transform: ["array", { key: "key", value: { selector: "value", transform: "string" }}] },
 		// eslint-disable-next-line
 } as const satisfies Filter.Mapping.RecordWithSelector<string>;
 const mappingConfig: Filter.Mapping = {
@@ -50,7 +53,8 @@ const mappingConfig: Filter.Mapping = {
 }
 const tableSchema: Listener.Configuration.BigQuery.Api.BaseField<Extract<keyof typeof mapping, string>>[] = [
 	{ name: "stringVal", type: "STRING" },
-	{ name: "numVal", type: "INTEGER" },
+	{ name: "integer", type: "INTEGER" },
+	{ name: "numeric", type: "NUMERIC" },
 	{ name: "tupleKey", type: "STRING" },
 	{ name: "tupleInner", type: "STRING" },
 	{ name: "arrayInner", type: "STRING", mode: "REPEATED" },
@@ -67,10 +71,16 @@ const tableSchema: Listener.Configuration.BigQuery.Api.BaseField<Extract<keyof t
 			{ name: "value", type: "STRING" },
 		]
 	},
+	{ name: "num2strMap", type: "RECORD", mode: "REPEATED", fields: [
+			{ name: "key", type: "NUMERIC" },
+			{ name: "value", type: "NUMERIC" },
+		]
+	},
 ]
 const result = {
 	stringVal: "test",
-	numVal: 2,
+	integer: 2,
+	numeric: 2.34,
 	tupleKey: "key",
 	tupleInner: "value",
 	arrayInner: ["value0", "value1", "value2", "value3"],
@@ -82,6 +92,10 @@ const result = {
 		{ key: "prop1", value: "hej" },
 		{ key: "prop2", value: "haj" },
 	],
+	num2strMap: [
+		{ key: "pi", value: "3.1416" },
+		{ key: "phi", value: "1.618" },
+	]
 }
 const configuration: Listener.Configuration.BigQuery.BaseConfiguration = {
 	name: "test-events",

--- a/packages/common/filter/Mapping/index.ts
+++ b/packages/common/filter/Mapping/index.ts
@@ -33,7 +33,7 @@ export namespace Mapping {
 	export type Getter<T extends string = string> = {
 		selector: MaybeArray<T>
 		default?: MaybeArray<number | string | boolean>
-		transform?: Transform | RecordWithSelector<string>
+		transform?: Transform | RecordWithSelector<string> | [Extract<Transform, "array">, RecordWithSelector<string>]
 	}
 	export namespace Getter {
 		type Default = number | string | boolean
@@ -47,9 +47,18 @@ export namespace Mapping {
 			selector: isly.union<string | string[], string, string[]>(isly.string(), isly.string().array()),
 			default: defaultType,
 			transform: isly
-				.union<Transform | RecordWithSelector<string>, Transform, RecordWithSelector<string>>(
+				.union<
+					Transform | RecordWithSelector<string> | [Extract<Transform, "array">, RecordWithSelector<string>],
+					Transform,
+					RecordWithSelector<string>,
+					[Extract<Transform, "array">, RecordWithSelector<string>]
+				>(
 					Transform.type,
-					RecordWithSelector.type
+					RecordWithSelector.type,
+					isly.tuple<[Extract<Transform, "array">, RecordWithSelector<string>]>(
+						isly.string(["array"]),
+						RecordWithSelector.type
+					)
 				)
 				.optional(),
 		})


### PR DESCRIPTION
+ additional tests for mapping numbers.
#### Rationale
Objects with generic (or a large number of) keys could previously be transformed into an array of objects for every key-value pair, but those objects could not be further transformed until now.